### PR TITLE
feat(ssemessage): Added ID Field

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,5 +1,6 @@
 package constants
 
+const DATA_EVENTID_FORMAT string = "id: %s\n"
 const DATA_TRANSMIT_FORMAT string = "data: %s\n\n"
 const DATA_TYPE_FORMAT string = "event: %s\n"
 

--- a/ssehandler.go
+++ b/ssehandler.go
@@ -87,6 +87,7 @@ func (sh *SSEHandler) EndpointFunc(w http.ResponseWriter, r *http.Request) {
 			// note: it is recommended that the data to be transmitted is
 			// in JSON format. this will help avoid transmission errors.
 			fmt.Fprintf(w, sseconst.DATA_TYPE_FORMAT, val.Event)
+			fmt.Fprintf(w, sseconst.DATA_EVENTID_FORMAT, val.Id)
 			fmt.Fprintf(w, sseconst.DATA_TRANSMIT_FORMAT, val.Data)
 			flusher.Flush()
 		}

--- a/structs.go
+++ b/structs.go
@@ -17,6 +17,8 @@ type SSEHandlerOption struct {
 type SSEMessage struct {
 	// name of the event that will be transmitted.
 	Event string
+	// id assigned to the event type. (optional)
+	Id string
 	// data to be transmitted to the client.
 	//
 	// for best results, this should be a JSON object.


### PR DESCRIPTION
## Description

An event id field has been added to the `SSEMessage` struct. This field is of type string, is optional, and is meant to be used if the user means to pass an event id along with the message.

## Associated Issues

#1 : Add Event ID Field